### PR TITLE
Dev container: smaller docker images

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,18 +9,17 @@ ENV HYLO_LLVM_DOWNLOAD_URL="https://github.com/hylo-lang/llvm-build/releases/dow
 
 RUN apt-get clean
 RUN apt-get update
-RUN apt-get install -y tar zstd libzstd1 libzstd-dev
+RUN apt-get install -y tar zstd libzstd1 libzstd-dev curl
 
-ADD ${HYLO_LLVM_DOWNLOAD_URL}/${HYLO_LLVM_BUILD_RELEASE}/llvm-${LLVM_VERSION}-x86_64-unknown-linux-gnu-Debug.tar.zst /opt
-RUN tar -x --zstd -f /opt/llvm-${LLVM_VERSION}-x86_64-unknown-linux-gnu-Debug.tar.zst -C /opt
+RUN <<EOT bash
+set -e
+set -o pipefail
 
-ADD ${HYLO_LLVM_DOWNLOAD_URL}/${HYLO_LLVM_BUILD_RELEASE}/llvm-${LLVM_VERSION}-x86_64-unknown-linux-gnu-MinSizeRel.tar.zst /opt
-RUN tar -x --zstd -f /opt/llvm-${LLVM_VERSION}-x86_64-unknown-linux-gnu-MinSizeRel.tar.zst -C /opt
+file_prefix="llvm-\${LLVM_VERSION}-\$(uname -m)-unknown-linux-gnu"
+url_prefix="\${HYLO_LLVM_DOWNLOAD_URL}/\${HYLO_LLVM_BUILD_RELEASE}/\$file_prefix"
 
-ADD ${HYLO_LLVM_DOWNLOAD_URL}/${HYLO_LLVM_BUILD_RELEASE}/llvm-${LLVM_VERSION}-aarch64-unknown-linux-gnu-Debug.tar.zst /opt
-RUN tar -x --zstd -f /opt/llvm-${LLVM_VERSION}-aarch64-unknown-linux-gnu-Debug.tar.zst -C /opt
-
-ADD ${HYLO_LLVM_DOWNLOAD_URL}/${HYLO_LLVM_BUILD_RELEASE}/llvm-${LLVM_VERSION}-aarch64-unknown-linux-gnu-MinSizeRel.tar.zst /opt
-RUN tar -x --zstd -f /opt/llvm-${LLVM_VERSION}-aarch64-unknown-linux-gnu-MinSizeRel.tar.zst -C /opt
-
-RUN rm /opt/llvm-*.tar.zst
+for build_type in Debug MinSizeRel; do
+  curl -L "\${url_prefix}-\${build_type}.tar.zst" | tar -x --zstd -C /opt
+  ln -s /opt/\${file_prefix}-\${build_type} /opt/llvm-\${build_type}
+done
+EOT

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,8 @@
     "runArgs": [
         "--cap-add=SYS_PTRACE",
         "--security-opt",
-        "seccomp=unconfined"
+        "seccomp=unconfined",
+        "--network=host"
     ],
     // Configure tool-specific properties.
     "customizations": {

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -5,8 +5,5 @@ set -o pipefail
 echo "Hylo LLVM build type: $HYLO_LLVM_BUILD_TYPE"
 echo
 
-ln -s /opt/llvm-*-$(uname -m)-*-Debug /opt/llvm-Debug
-ln -s /opt/llvm-*-$(uname -m)-*-MinSizeRel /opt/llvm-MinSizeRel
-
 export PATH="/opt/llvm-$HYLO_LLVM_BUILD_TYPE/bin:$PATH"
-./Tools/make-pkgconfig.sh /usr/local/lib/pkgconfig/llvm.pc
+./Tools/make-pkgconfig.sh /usr/local/lib/pkgconfig/llvm.pc > /dev/null


### PR DESCRIPTION
Download only the elements needed for the target architecture.

Requires `--network=host` passed to `docker build` if not using a devcontainer to build the image.