### PR TITLE
Remove extraneous dispose

### DIFF
--- a/Sources/SwiftyLLVM/Target.swift
+++ b/Sources/SwiftyLLVM/Target.swift
@@ -49,7 +49,6 @@ public struct Target {
   /// The name of the target.
   public var name: String {
     guard let s = LLVMGetTargetName(llvm) else { return "" }
-    defer { LLVMDisposeMessage(UnsafeMutablePointer(mutating: s)) }
     return .init(cString: s)
   }
 

--- a/Tests/LLVMTests/TargetTests.swift
+++ b/Tests/LLVMTests/TargetTests.swift
@@ -3,7 +3,9 @@ import XCTest
 
 final class TargetTests: XCTestCase {
 
-  func testHostTargetName() throws {
+  func testHostTargetNameCopyValidity() throws {
+    // Check that a copy of the target name can still be used after the lifetime
+    // of the Target ends.
     let h = try Target.host()
     let n = h.name
     XCTAssertFalse(n.isEmpty)

--- a/Tests/LLVMTests/TargetTests.swift
+++ b/Tests/LLVMTests/TargetTests.swift
@@ -1,0 +1,12 @@
+import SwiftyLLVM
+import XCTest
+
+final class TargetTests: XCTestCase {
+
+  func testHostTargetName() throws {
+    let h = try Target.host()
+    let n = h.name
+    XCTAssertFalse(n.isEmpty)
+  }
+
+}


### PR DESCRIPTION
`LLVMGetTargetName` doesn't return a newly allocated string. This crashes under certain circumstances.