### PR TITLE
Add support for atomic operations

### DIFF
--- a/Coverage.md
+++ b/Coverage.md
@@ -995,7 +995,7 @@
 - [ ] LLVMGetWeak
 - [ ] LLVMSetWeak
 - [ ] LLVMGetOrdering
-- [ ] LLVMSetOrdering
+- [x] LLVMSetOrdering
 - [ ] LLVMGetAtomicRMWBinOp
 - [ ] LLVMSetAtomicRMWBinOp
 - [x] LLVMBuildTrunc

--- a/Coverage.md
+++ b/Coverage.md
@@ -997,7 +997,7 @@
 - [ ] LLVMGetOrdering
 - [x] LLVMSetOrdering
 - [ ] LLVMGetAtomicRMWBinOp
-- [ ] LLVMSetAtomicRMWBinOp
+- [x] LLVMSetAtomicRMWBinOp
 - [x] LLVMBuildTrunc
 
   `Module.insertTrunc(_:to:at:)`
@@ -1072,18 +1072,18 @@
 - [ ] LLVMBuildIsNull
 - [ ] LLVMBuildIsNotNull
 - [ ] LLVMBuildPtrDiff2
-- [ ] LLVMBuildFence
-- [ ] LLVMBuildAtomicRMW
-- [ ] LLVMBuildAtomicCmpXchg
+- [x] LLVMBuildFence
+- [x] LLVMBuildAtomicRMW
+- [x] LLVMBuildAtomicCmpXchg
 - [ ] LLVMGetNumMaskElements
 - [ ] LLVMGetUndefMaskElem
 - [ ] LLVMGetMaskValue
 - [ ] LLVMIsAtomicSingleThread
-- [ ] LLVMSetAtomicSingleThread
+- [x] LLVMSetAtomicSingleThread
 - [ ] LLVMGetCmpXchgSuccessOrdering
-- [ ] LLVMSetCmpXchgSuccessOrdering
+- [x] LLVMSetCmpXchgSuccessOrdering
 - [ ] LLVMGetCmpXchgFailureOrdering
-- [ ] LLVMSetCmpXchgFailureOrdering
+- [x] LLVMSetCmpXchgFailureOrdering
 
 ## Memory Buffers
 

--- a/Sources/SwiftyLLVM/AtomicOrdering.swift
+++ b/Sources/SwiftyLLVM/AtomicOrdering.swift
@@ -1,0 +1,88 @@
+internal import llvmc
+
+/// The ordering for an atomic operation.
+///
+/// See https://en.cppreference.com/w/cpp/atomic/memory_order
+public enum AtomicOrdering {
+
+  /// A load or a store operation that is not atomic.
+  ///
+  /// Matches C++ memory model for non-atomic shared variables.
+  case notAtomic
+
+  /// Lowest level of atomicity, guarantees somewhat sane results, lock free.
+  ///
+  /// Matches Java memory model for shared variables.
+  case unordered
+
+  /// Guarantees that if you take all the operations affecting a specific address, a consistent
+  /// ordering exists.
+  ///
+  /// Matches the C++ memory_order_relaxed memory order.
+  case monotonic
+
+  /// A load that is an *acquire operation*, or a barrier necessary to acquire a lock to access
+  /// other memory with normal loads and stores.
+  ///
+  /// Matches the C++ memory_order_acquire memory order.
+  case acquire
+
+  /// A store that is a *release operation*, or a barrier necessary to release a lock.
+  ///
+  /// Matches the C++ memory_order_release memory order.
+  case release
+
+  /// A read-modify-write operation with this memory order is both an *acquire operation* and a
+  /// *release operation*, or a barrier that is both an Acquire and a Release barrier.
+  ///
+  /// Matches the C++ memory_order_acq_rel memory order.
+  case acquireRelease
+
+  /// Same as `acquireRelease`, but also provides a single total order of all modifications.
+  ///
+  /// Matches the C++ memory_order_seq_cst memory order.
+  case sequentiallyConsistent
+
+  /// Creates an instance from its LLVM representation.
+  internal init(llvm: LLVMAtomicOrdering) {
+    switch llvm {
+    case LLVMAtomicOrderingNotAtomic:
+      self = .notAtomic
+    case LLVMAtomicOrderingUnordered:
+      self = .unordered
+    case LLVMAtomicOrderingMonotonic:
+      self = .monotonic
+    case LLVMAtomicOrderingAcquire:
+      self = .acquire
+    case LLVMAtomicOrderingRelease:
+      self = .release
+    case LLVMAtomicOrderingAcquireRelease:
+      self = .acquireRelease
+    case LLVMAtomicOrderingSequentiallyConsistent:
+      self = .sequentiallyConsistent
+    default:
+      fatalError("unsupported atomic ordering")
+    }
+  }
+
+  /// The LLVM representation of this instance.
+  internal var llvm: LLVMAtomicOrdering {
+    switch self {
+    case .notAtomic:
+      return LLVMAtomicOrderingNotAtomic
+    case .unordered:
+      return LLVMAtomicOrderingUnordered
+    case .monotonic:
+      return LLVMAtomicOrderingMonotonic
+    case .acquire:
+      return LLVMAtomicOrderingAcquire
+    case .release:
+      return LLVMAtomicOrderingRelease
+    case .acquireRelease:
+      return LLVMAtomicOrderingAcquireRelease
+    case .sequentiallyConsistent:
+      return LLVMAtomicOrderingSequentiallyConsistent
+    }
+  }
+
+}

--- a/Sources/SwiftyLLVM/AtomicRMWBinOp.swift
+++ b/Sources/SwiftyLLVM/AtomicRMWBinOp.swift
@@ -1,0 +1,112 @@
+internal import llvmc
+
+/// The type of an atomic read-modify-write binary operation.
+public enum AtomicRMWBinOp {
+
+  /// Set the new value and return the one old.
+  case xchg
+  /// Add a value and return the old one.
+  case add
+  /// Subtract a value and return the old one.
+  case sub
+  /// And a value and return the old one.
+  case and
+  /// Not-And a value and return the old one.
+  case nand
+  /// OR a value and return the old one.
+  case or
+  /// Xor a value and return the old one.
+  case xor
+  /// Sets the value if it's greater than the original using a signed comparison and return the old one.
+  case max
+  /// Sets the value if it's Smaller than the original using a signed comparison and return the old one.
+  case min
+  /// Sets the value if it's greater than the original using an unsigned comparison and return the old one.
+  case uMax
+  /// Sets the value if it's greater than the  original using an unsigned comparison and return  the old one.
+  case uMin
+  /// Add a floating point value and return the  old one.
+  case fAdd
+  /// Subtract a floating point value and return the old one.
+  case fSub
+  /// Sets the value if it's greater than the original using an floating point comparison and return the old one.
+  case fMax
+  /// Sets the value if it's smaller than the original using an floating point comparison and return the old one.
+  case fMin
+
+
+  /// Creates an instance from its LLVM representation.
+  internal init(llvm: LLVMAtomicRMWBinOp) {
+    switch llvm {
+    case LLVMAtomicRMWBinOpXchg:
+      self = .xchg
+    case LLVMAtomicRMWBinOpAdd:
+      self = .add
+    case LLVMAtomicRMWBinOpSub:
+      self = .sub
+    case LLVMAtomicRMWBinOpAnd:
+      self = .and
+    case LLVMAtomicRMWBinOpNand:
+      self = .nand
+    case LLVMAtomicRMWBinOpOr:
+      self = .or
+    case LLVMAtomicRMWBinOpXor:
+      self = .xor
+    case LLVMAtomicRMWBinOpMax:
+      self = .max
+    case LLVMAtomicRMWBinOpMin:
+      self = .min
+    case LLVMAtomicRMWBinOpUMax:
+      self = .uMax
+    case LLVMAtomicRMWBinOpUMin:
+      self = .uMin
+    case LLVMAtomicRMWBinOpFAdd:
+      self = .fAdd
+    case LLVMAtomicRMWBinOpFSub:
+      self = .fSub
+    case LLVMAtomicRMWBinOpFMax:
+      self = .fMax
+    case LLVMAtomicRMWBinOpFMin:
+      self = .fMin
+    default:
+      fatalError("unsupported atomic RMW binary operation")
+    }
+  }
+
+  /// The LLVM representation of this instance.
+  internal var llvm: LLVMAtomicRMWBinOp {
+    switch self {
+    case .xchg:
+      return LLVMAtomicRMWBinOpXchg
+    case .add:
+      return LLVMAtomicRMWBinOpAdd
+    case .sub:
+      return LLVMAtomicRMWBinOpSub
+    case .and:
+      return LLVMAtomicRMWBinOpAnd
+    case .nand:
+      return LLVMAtomicRMWBinOpNand
+    case .or:
+      return LLVMAtomicRMWBinOpOr
+    case .xor:
+      return LLVMAtomicRMWBinOpXor
+    case .max:
+      return LLVMAtomicRMWBinOpMax
+    case .min:
+      return LLVMAtomicRMWBinOpMin
+    case .uMax:
+      return LLVMAtomicRMWBinOpUMax
+    case .uMin:
+      return LLVMAtomicRMWBinOpUMin
+    case .fAdd:
+      return LLVMAtomicRMWBinOpFAdd
+    case .fSub:
+      return LLVMAtomicRMWBinOpFSub
+    case .fMax:
+      return LLVMAtomicRMWBinOpFMax
+    case .fMin:
+      return LLVMAtomicRMWBinOpFMin
+    }
+  }
+
+}

--- a/Sources/SwiftyLLVM/Module.swift
+++ b/Sources/SwiftyLLVM/Module.swift
@@ -622,6 +622,10 @@ public struct Module {
     .init(LLVMBuildStore(p.llvm, value.llvm.raw, location.llvm.raw))
   }
 
+  public mutating func setOrdering(_ ordering: AtomicOrdering, for i: Instruction) {
+    LLVMSetOrdering(i.llvm.raw, ordering.llvm)
+  }
+
   // MARK: Terminators
 
   @discardableResult

--- a/Sources/SwiftyLLVM/Module.swift
+++ b/Sources/SwiftyLLVM/Module.swift
@@ -622,8 +622,59 @@ public struct Module {
     .init(LLVMBuildStore(p.llvm, value.llvm.raw, location.llvm.raw))
   }
 
+  // MARK: Atomics
+
   public mutating func setOrdering(_ ordering: AtomicOrdering, for i: Instruction) {
     LLVMSetOrdering(i.llvm.raw, ordering.llvm)
+  }
+
+  public mutating func setCmpXchgSuccessOrdering(_ ordering: AtomicOrdering, for i: Instruction) {
+    LLVMSetCmpXchgSuccessOrdering(i.llvm.raw, ordering.llvm)
+  }
+
+  public mutating func setCmpXchgFailureOrdering(_ ordering: AtomicOrdering, for i: Instruction) {
+    LLVMSetCmpXchgFailureOrdering(i.llvm.raw, ordering.llvm)
+  }
+
+  public mutating func setAtomicRMWBinOp(_ binOp: AtomicRMWBinOp, for i: Instruction) {
+    LLVMSetAtomicRMWBinOp(i.llvm.raw, binOp.llvm)
+  }
+
+  public mutating func setAtomicSingleThread(for i: Instruction) {
+    LLVMSetAtomicSingleThread(i.llvm.raw, 1)
+  }
+
+  public mutating func insertAtomicCmpXchg(
+    _ atomic: IRValue,
+    old: IRValue,
+    new: IRValue,
+    successOrdering: AtomicOrdering,
+    failureOrdering: AtomicOrdering,
+    weak: Bool,
+    singleThread: Bool,
+    at p: InsertionPoint
+  ) -> Instruction {
+    let i = Instruction(LLVMBuildAtomicCmpXchg(p.llvm, atomic.llvm.raw, old.llvm.raw, new.llvm.raw, successOrdering.llvm, failureOrdering.llvm, singleThread ? 1 : 0))
+    if weak {
+      LLVMSetWeak(i.llvm.raw, 1)
+    }
+    return i
+  }
+
+  public mutating func insertAtomicRMW(
+    _ atomic: IRValue,
+    operation: AtomicRMWBinOp,
+    value: IRValue,
+    ordering: AtomicOrdering,
+    singleThread: Bool,
+    at p: InsertionPoint
+  ) -> Instruction {
+    .init(LLVMBuildAtomicRMW(p.llvm, operation.llvm, atomic.llvm.raw, value.llvm.raw, ordering.llvm, singleThread ? 1 : 0))
+  }
+
+  @discardableResult
+  public mutating func insertFence(_ ordering: AtomicOrdering, singleThread: Bool, at p: InsertionPoint) -> Instruction {
+    .init(LLVMBuildFence(p.llvm, ordering.llvm, singleThread ? 1 : 0, ""))
   }
 
   // MARK: Terminators

--- a/Tests/LLVMTests/CodeGenerationTests.swift
+++ b/Tests/LLVMTests/CodeGenerationTests.swift
@@ -196,31 +196,275 @@ extension Module {
 
     let b0 = appendBlock(named: "b0", to: f)
 
-    // %0 = alloca [16 x i8], align 8
+    // %0 = alloca i64, align 8
     // %1 = alloca double, align 8
-    let x0 = insertAlloca(ArrayType(16, i8, in: &self), at: endOf(b0))
-    setAlignment(8, for: x0)
+    let x0 = insertAlloca(i64, at: endOf(b0))
     let x1 = insertAlloca(double, at: endOf(b0))
 
     // store atomic double 0x400921FB54442D18, ptr %1 monotonic, align 8
+    // store atomic double 0x400921FB54442D18, ptr %1 release, align 8
+    // store atomic double 0x400921FB54442D18, ptr %1 seq_cst, align 8
     let s1 = insertStore(double(.pi), to: x1, at: endOf(b0))
     setOrdering(.monotonic, for: s1)
-    // store atomic double 0x400921FB54442D18, ptr %1 release, align 8
     let s2 = insertStore(double(.pi), to: x1, at: endOf(b0))
     setOrdering(.release, for: s2)
-    // store atomic double 0x400921FB54442D18, ptr %1 seq_cst, align 8
     let s3 = insertStore(double(.pi), to: x1, at: endOf(b0))
     setOrdering(.sequentiallyConsistent, for: s3)
 
     // %2 = load atomic double, ptr %1 monotonic, align 8
+    // %3 = load atomic double, ptr %1 acquire, align 8
+    // %4 = load atomic double, ptr %1 seq_cst, align 8
     let x2 = insertLoad(double, from: x1, at: endOf(b0))
     setOrdering(.monotonic, for: x2)
-    // %3 = load atomic double, ptr %1 acquire, align 8
     let x3 = insertLoad(double, from: x1, at: endOf(b0))
     setOrdering(.acquire, for: x3)
-    // %4 = load atomic double, ptr %1 seq_cst, align 8
     let x4 = insertLoad(double, from: x1, at: endOf(b0))
     setOrdering(.sequentiallyConsistent, for: x4)
+
+    // %5 = atomicrmw xchg ptr %1, double 0x400921FB54442D18 monotonic, align 8
+    // %6 = atomicrmw xchg ptr %1, double 0x400921FB54442D18 acquire, align 8
+    // %7 = atomicrmw xchg ptr %1, double 0x400921FB54442D18 release, align 8
+    // %8 = atomicrmw xchg ptr %1, double 0x400921FB54442D18 acq_rel, align 8
+    // %9 = atomicrmw xchg ptr %1, double 0x400921FB54442D18 seq_cst, align 8
+    let _ = insertAtomicRMW(x1, operation: .xchg, value: double(.pi), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .xchg, value: double(.pi), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .xchg, value: double(.pi), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .xchg, value: double(.pi), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .xchg, value: double(.pi), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %10 = atomicrmw add ptr %0, i64 11 monotonic, align 8
+    // %11 = atomicrmw add ptr %0, i64 11 acquire, align 8
+    // %12 = atomicrmw add ptr %0, i64 11 release, align 8
+    // %13 = atomicrmw add ptr %0, i64 11 acq_rel, align 8
+    // %14 = atomicrmw add ptr %0, i64 11 seq_cst, align 8
+    let _ = insertAtomicRMW(x0, operation: .add, value: i64(11), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .add, value: i64(11), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .add, value: i64(11), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .add, value: i64(11), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .add, value: i64(11), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %15 = atomicrmw fadd ptr %1, double 0x400921FB54442D18 monotonic, align 8
+    // %16 = atomicrmw fadd ptr %1, double 0x400921FB54442D18 acquire, align 8
+    // %17 = atomicrmw fadd ptr %1, double 0x400921FB54442D18 release, align 8
+    // %18 = atomicrmw fadd ptr %1, double 0x400921FB54442D18 acq_rel, align 8
+    // %19 = atomicrmw fadd ptr %1, double 0x400921FB54442D18 seq_cst, align 8
+    let _ = insertAtomicRMW(x1, operation: .fAdd, value: double(.pi), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fAdd, value: double(.pi), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fAdd, value: double(.pi), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fAdd, value: double(.pi), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fAdd, value: double(.pi), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %20 = atomicrmw sub ptr %0, i64 13 monotonic, align 8
+    // %21 = atomicrmw sub ptr %0, i64 13 acquire, align 8
+    // %22 = atomicrmw sub ptr %0, i64 13 release, align 8
+    // %23 = atomicrmw sub ptr %0, i64 13 acq_rel, align 8
+    // %24 = atomicrmw sub ptr %0, i64 13 seq_cst, align 8
+    let _ = insertAtomicRMW(x0, operation: .sub, value: i64(13), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .sub, value: i64(13), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .sub, value: i64(13), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .sub, value: i64(13), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .sub, value: i64(13), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %25 = atomicrmw fsub ptr %1, double 0x400921FB54442D18 monotonic, align 8
+    // %26 = atomicrmw fsub ptr %1, double 0x400921FB54442D18 acquire, align 8
+    // %27 = atomicrmw fsub ptr %1, double 0x400921FB54442D18 release, align 8
+    // %28 = atomicrmw fsub ptr %1, double 0x400921FB54442D18 acq_rel, align 8
+    // %29 = atomicrmw fsub ptr %1, double 0x400921FB54442D18 seq_cst, align 8
+    let _ = insertAtomicRMW(x1, operation: .fSub, value: double(.pi), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fSub, value: double(.pi), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fSub, value: double(.pi), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fSub, value: double(.pi), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fSub, value: double(.pi), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %30 = atomicrmw max ptr %0, i64 17 monotonic, align 8
+    // %31 = atomicrmw max ptr %0, i64 17 acquire, align 8
+    // %32 = atomicrmw max ptr %0, i64 17 release, align 8
+    // %33 = atomicrmw max ptr %0, i64 17 acq_rel, align 8
+    // %34 = atomicrmw max ptr %0, i64 17 seq_cst, align 8
+    let _ = insertAtomicRMW(x0, operation: .max, value: i64(17), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .max, value: i64(17), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .max, value: i64(17), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .max, value: i64(17), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .max, value: i64(17), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %35 = atomicrmw umax ptr %0, i64 19 monotonic, align 8
+    // %36 = atomicrmw umax ptr %0, i64 19 acquire, align 8
+    // %37 = atomicrmw umax ptr %0, i64 19 release, align 8
+    // %38 = atomicrmw umax ptr %0, i64 19 acq_rel, align 8
+    // %39 = atomicrmw umax ptr %0, i64 19 seq_cst, align 8
+    let _ = insertAtomicRMW(x0, operation: .uMax, value: i64(19), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .uMax, value: i64(19), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .uMax, value: i64(19), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .uMax, value: i64(19), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .uMax, value: i64(19), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %40 = atomicrmw fmax ptr %1, double 0x400921FB54442D18 monotonic, align 8
+    // %41 = atomicrmw fmax ptr %1, double 0x400921FB54442D18 acquire, align 8
+    // %42 = atomicrmw fmax ptr %1, double 0x400921FB54442D18 release, align 8
+    // %43 = atomicrmw fmax ptr %1, double 0x400921FB54442D18 acq_rel, align 8
+    // %44 = atomicrmw fmax ptr %1, double 0x400921FB54442D18 seq_cst, align 8
+    let _ = insertAtomicRMW(x1, operation: .fMax, value: double(.pi), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fMax, value: double(.pi), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fMax, value: double(.pi), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fMax, value: double(.pi), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fMax, value: double(.pi), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %45 = atomicrmw min ptr %0, i64 17 monotonic, align 8
+    // %46 = atomicrmw min ptr %0, i64 17 acquire, align 8
+    // %47 = atomicrmw min ptr %0, i64 17 release, align 8
+    // %48 = atomicrmw min ptr %0, i64 17 acq_rel, align 8
+    // %49 = atomicrmw min ptr %0, i64 17 seq_cst, align 8
+    let _ = insertAtomicRMW(x0, operation: .min, value: i64(17), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .min, value: i64(17), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .min, value: i64(17), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .min, value: i64(17), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .min, value: i64(17), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %50 = atomicrmw umin ptr %0, i64 19 monotonic, align 8
+    // %51 = atomicrmw umin ptr %0, i64 19 acquire, align 8
+    // %52 = atomicrmw umin ptr %0, i64 19 release, align 8
+    // %53 = atomicrmw umin ptr %0, i64 19 acq_rel, align 8
+    // %54 = atomicrmw umin ptr %0, i64 19 seq_cst, align 8
+    let _ = insertAtomicRMW(x0, operation: .uMin, value: i64(19), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .uMin, value: i64(19), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .uMin, value: i64(19), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .uMin, value: i64(19), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .uMin, value: i64(19), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %55 = atomicrmw fmin ptr %1, double 0x400921FB54442D18 monotonic, align 8
+    // %56 = atomicrmw fmin ptr %1, double 0x400921FB54442D18 acquire, align 8
+    // %57 = atomicrmw fmin ptr %1, double 0x400921FB54442D18 release, align 8
+    // %58 = atomicrmw fmin ptr %1, double 0x400921FB54442D18 acq_rel, align 8
+    // %59 = atomicrmw fmin ptr %1, double 0x400921FB54442D18 seq_cst, align 8
+    let _ = insertAtomicRMW(x1, operation: .fMin, value: double(.pi), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fMin, value: double(.pi), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fMin, value: double(.pi), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fMin, value: double(.pi), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x1, operation: .fMin, value: double(.pi), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %60 = atomicrmw and ptr %0, i64 23 monotonic, align 8
+    // %61 = atomicrmw and ptr %0, i64 23 acquire, align 8
+    // %62 = atomicrmw and ptr %0, i64 23 release, align 8
+    // %63 = atomicrmw and ptr %0, i64 23 acq_rel, align 8
+    // %64 = atomicrmw and ptr %0, i64 23 seq_cst, align 8
+    let _ = insertAtomicRMW(x0, operation: .and, value: i64(23), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .and, value: i64(23), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .and, value: i64(23), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .and, value: i64(23), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .and, value: i64(23), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %65 = atomicrmw nand ptr %0, i64 29 monotonic, align 8
+    // %66 = atomicrmw nand ptr %0, i64 29 acquire, align 8
+    // %67 = atomicrmw nand ptr %0, i64 29 release, align 8
+    // %68 = atomicrmw nand ptr %0, i64 29 acq_rel, align 8
+    // %69 = atomicrmw nand ptr %0, i64 29 seq_cst, align 8
+    let _ = insertAtomicRMW(x0, operation: .nand, value: i64(29), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .nand, value: i64(29), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .nand, value: i64(29), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .nand, value: i64(29), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .nand, value: i64(29), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %70 = atomicrmw or ptr %0, i64 31 monotonic, align 8
+    // %71 = atomicrmw or ptr %0, i64 31 acquire, align 8
+    // %72 = atomicrmw or ptr %0, i64 31 release, align 8
+    // %73 = atomicrmw or ptr %0, i64 31 acq_rel, align 8
+    // %74 = atomicrmw or ptr %0, i64 31 seq_cst, align 8
+    let _ = insertAtomicRMW(x0, operation: .or, value: i64(31), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .or, value: i64(31), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .or, value: i64(31), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .or, value: i64(31), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .or, value: i64(31), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %75 = atomicrmw xor ptr %0, i64 37 monotonic, align 8
+    // %76 = atomicrmw xor ptr %0, i64 37 acquire, align 8
+    // %77 = atomicrmw xor ptr %0, i64 37 release, align 8
+    // %78 = atomicrmw xor ptr %0, i64 37 acq_rel, align 8
+    // %79 = atomicrmw xor ptr %0, i64 37 seq_cst, align 8
+    let _ = insertAtomicRMW(x0, operation: .xor, value: i64(37), ordering: .monotonic, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .xor, value: i64(37), ordering: .acquire, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .xor, value: i64(37), ordering: .release, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .xor, value: i64(37), ordering: .acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicRMW(x0, operation: .xor, value: i64(37), ordering: .sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // %80 = cmpxchg ptr %0, i64 41, i64 43 monotonic monotonic, align 8
+    // %81 = cmpxchg ptr %0, i64 41, i64 43 monotonic acquire, align 8
+    // %82 = cmpxchg ptr %0, i64 41, i64 43 monotonic seq_cst, align 8
+    // %83 = cmpxchg ptr %0, i64 41, i64 43 acquire monotonic, align 8
+    // %84 = cmpxchg ptr %0, i64 41, i64 43 acquire acquire, align 8
+    // %85 = cmpxchg ptr %0, i64 41, i64 43 acquire seq_cst, align 8
+    // %86 = cmpxchg ptr %0, i64 41, i64 43 release monotonic, align 8
+    // %87 = cmpxchg ptr %0, i64 41, i64 43 release acquire, align 8
+    // %88 = cmpxchg ptr %0, i64 41, i64 43 release seq_cst, align 8
+    // %89 = cmpxchg ptr %0, i64 41, i64 43 acq_rel monotonic, align 8
+    // %90 = cmpxchg ptr %0, i64 41, i64 43 acq_rel acquire, align 8
+    // %91 = cmpxchg ptr %0, i64 41, i64 43 acq_rel seq_cst, align 8
+    // %92 = cmpxchg ptr %0, i64 41, i64 43 seq_cst monotonic, align 8
+    // %93 = cmpxchg ptr %0, i64 41, i64 43 seq_cst acquire, align 8
+    // %94 = cmpxchg ptr %0, i64 41, i64 43 seq_cst seq_cst, align 8
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .monotonic, failureOrdering: .monotonic, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .monotonic, failureOrdering: .acquire, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .monotonic, failureOrdering: .sequentiallyConsistent, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquire, failureOrdering: .monotonic, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquire, failureOrdering: .acquire, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquire, failureOrdering: .sequentiallyConsistent, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .release, failureOrdering: .monotonic, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .release, failureOrdering: .acquire, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .release, failureOrdering: .sequentiallyConsistent, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquireRelease, failureOrdering: .monotonic, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquireRelease, failureOrdering: .acquire, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquireRelease, failureOrdering: .sequentiallyConsistent, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .sequentiallyConsistent, failureOrdering: .monotonic, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .sequentiallyConsistent, failureOrdering: .acquire, weak: false, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .sequentiallyConsistent, failureOrdering: .sequentiallyConsistent, weak: false, singleThread: false, at: endOf(b0))
+
+    // %95 = cmpxchg weak ptr %0, i64 41, i64 43 monotonic monotonic, align 8
+    // %96 = cmpxchg weak ptr %0, i64 41, i64 43 monotonic acquire, align 8
+    // %97 = cmpxchg weak ptr %0, i64 41, i64 43 monotonic seq_cst, align 8
+    // %98 = cmpxchg weak ptr %0, i64 41, i64 43 acquire monotonic, align 8
+    // %99 = cmpxchg weak ptr %0, i64 41, i64 43 acquire acquire, align 8
+    // %100 = cmpxchg weak ptr %0, i64 41, i64 43 acquire seq_cst, align 8
+    // %101 = cmpxchg weak ptr %0, i64 41, i64 43 release monotonic, align 8
+    // %102 = cmpxchg weak ptr %0, i64 41, i64 43 release acquire, align 8
+    // %103 = cmpxchg weak ptr %0, i64 41, i64 43 release seq_cst, align 8
+    // %104 = cmpxchg weak ptr %0, i64 41, i64 43 acq_rel monotonic, align 8
+    // %105 = cmpxchg weak ptr %0, i64 41, i64 43 acq_rel acquire, align 8
+    // %106 = cmpxchg weak ptr %0, i64 41, i64 43 acq_rel seq_cst, align 8
+    // %107 = cmpxchg weak ptr %0, i64 41, i64 43 seq_cst monotonic, align 8
+    // %108 = cmpxchg weak ptr %0, i64 41, i64 43 seq_cst acquire, align 8
+    // %109 = cmpxchg weak ptr %0, i64 41, i64 43 seq_cst seq_cst, align 8
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .monotonic, failureOrdering: .monotonic, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .monotonic, failureOrdering: .acquire, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .monotonic, failureOrdering: .sequentiallyConsistent, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquire, failureOrdering: .monotonic, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquire, failureOrdering: .acquire, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquire, failureOrdering: .sequentiallyConsistent, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .release, failureOrdering: .monotonic, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .release, failureOrdering: .acquire, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .release, failureOrdering: .sequentiallyConsistent, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquireRelease, failureOrdering: .monotonic, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquireRelease, failureOrdering: .acquire, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .acquireRelease, failureOrdering: .sequentiallyConsistent, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .sequentiallyConsistent, failureOrdering: .monotonic, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .sequentiallyConsistent, failureOrdering: .acquire, weak: true, singleThread: false, at: endOf(b0))
+    let _ = insertAtomicCmpXchg(x0, old: i64(41), new: i64(43), successOrdering: .sequentiallyConsistent, failureOrdering: .sequentiallyConsistent, weak: true, singleThread: false, at: endOf(b0))
+
+    // fence acquire
+    // fence release
+    // fence acq_rel
+    // fence seq_cst
+    let _ = insertFence(.acquire, singleThread: false, at: endOf(b0))
+    let _ = insertFence(.release, singleThread: false, at: endOf(b0))
+    let _ = insertFence(.acquireRelease, singleThread: false, at: endOf(b0))
+    let _ = insertFence(.sequentiallyConsistent, singleThread: false, at: endOf(b0))
+
+    // fence syncscope("singlethread") acquire
+    // fence syncscope("singlethread") release
+    // fence syncscope("singlethread") acq_rel
+    // fence syncscope("singlethread") seq_cst
+    let _ = insertFence(.acquire, singleThread: true, at: endOf(b0))
+    let _ = insertFence(.release, singleThread: true, at: endOf(b0))
+    let _ = insertFence(.acquireRelease, singleThread: true, at: endOf(b0))
+    let _ = insertFence(.sequentiallyConsistent, singleThread: true, at: endOf(b0))
 
     // ret void
     insertReturn(at: endOf(b0))


### PR DESCRIPTION
Define `AtomicOrdering` and `setOrdering` to map directly to LLVM ordering constructs.

Define functions for buildings all atomic operations (Read-Modify-Write operations, CAS, fences).